### PR TITLE
Add webhook event

### DIFF
--- a/src/Api/Event/Factory.php
+++ b/src/Api/Event/Factory.php
@@ -35,6 +35,8 @@ class Factory
                     return new Seen($data);
                 case Type::FAILED:
                     return new Failed($data);
+                case Type::WEBHOOK:
+                    return new Webhook($data);
             }
         }
         throw new ApiException('Unknow event data');

--- a/src/Api/Event/Type.php
+++ b/src/Api/Event/Type.php
@@ -16,4 +16,5 @@ interface Type
     const UNSUBSCRIBED = 'unsubscribed';
     const CONVERSATION = 'conversation_started';
     const MESSAGE = 'message';
+    const WEBHOOK = 'webhook';
 }

--- a/src/Api/Event/Webhook.php
+++ b/src/Api/Event/Webhook.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Viber\Api\Event;
+
+use Viber\Api\Event;
+
+/**
+ * Triggers when setting a webhook
+ *
+ * @author An Hoang <hoangthienan@gmail.com>
+ */
+class Webhook extends Event
+{
+}


### PR DESCRIPTION
When i set webhook callback
The expected HTTP response to the callback is 200 OK with callback data

`{  
	"event":"webhook",  
	"timestamp":1457764197627,  
	"message_token":‎4912661846655238145  
}`

but lib throw new error

`throw new ApiException('Unknow event data');`