### PR TITLE
FIX json_decode long int parse as float

### DIFF
--- a/src/Api/Response.php
+++ b/src/Api/Response.php
@@ -28,7 +28,7 @@ class Response
     public static function create(\GuzzleHttp\Psr7\Response $response)
     {
         // - validate body
-        $data = json_decode($response->getBody(), true);
+        $data = json_decode($response->getBody(), true, 512, JSON_BIGINT_AS_STRING);
         if (empty($data)) {
             throw new ApiException('Invalid response body');
         }


### PR DESCRIPTION
С помощю getData() можно перехватывать свойства только что отправленных сообщений, например: 
$message_token = $bot->getClient()->sendMessage($message)->getData()['message_token'];
Но поскольку токен длинное целое json_decode с параметрами по умолчанию распарсит его как float, обрезав. Что бы этого избежать, включена  JSON_BIGINT_AS_STRING.