### PR TITLE
Upgrade guzzle version to last active

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "guzzlehttp/guzzle": "^6.2"
+        "guzzlehttp/guzzle": "^6.2 | ^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The lib work fine with Guzzle:7.4. Tested on [docs/first-steps.md](https://github.com/Bogdaan/viber-bot-php/blob/master/docs/first-steps.md)
Unit tests result the same as Guzzle:^6.0